### PR TITLE
Remove workaround for wrong packaging of `jxbrowser-cross-platform`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,9 +49,7 @@ subprojects {
     dependencies {
         // Cross-platform dependency
         //-------------------------
-        compile("com.teamdev.jxbrowser:jxbrowser-cross-platform:${jxBrowserVersion}@pom") {
-            transitive = true
-        }
+        compile "com.teamdev.jxbrowser:jxbrowser-cross-platform:${jxBrowserVersion}"
 
         /*
            For having only platform-dependent dependency:


### PR DESCRIPTION
This PR removes the workaround added in the 65800aa8cbc3e4e5369aee9e2033be13cd0914c2 commit, because the required `<packaging>pom</packaging>` attribute now exists in the appropriate [pom](http://maven.teamdev.com/repository/products/com/teamdev/jxbrowser/jxbrowser-cross-platform/6.19.1/jxbrowser-cross-platform-6.19.1.pom) file for `jxbrowser-cross-platform` on http://maven.teamdev.com/.

**Note:** the fix has been applied for JxBrowser 6.19.1 and higher.