### PR TITLE
Use ECMAScript 6 in DOM listening guide

### DIFF
--- a/tutorials/content-changes/src/main/resources/observer.js
+++ b/tutorials/content-changes/src/main/resources/observer.js
@@ -1,9 +1,9 @@
-var element = document.getElementById('counter');
-var observer = new MutationObserver(
+const element = document.getElementById('counter');
+const observer = new MutationObserver(
     function(mutations) {
         window.java.onDomChanged(element.innerHTML);
     });
-var config = {childList: true};
+const config = {childList: true};
 observer.observe(element, config);
 
 


### PR DESCRIPTION
This PR migrates JS code in the content listening tutorial to ES6.