### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+sudo: false
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       osx_image: xcode9.3
 
 before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux"     ]]; then export DISPLAY=:99.0    ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux"     ]]; then sh -e /etc/init.d/xvfb start    ; fi
   - chmod +x gradlew
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
       jdk: oraclejdk8
     - os: linux
       jdk: oraclejdk9
+    - os: linux
+      dist: xenial
+      jdk: oraclejdk8
     - os: osx
       osx_image: xcode9.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+
+script:
+ - ./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: java
 sudo: false
 
-os:
-  - linux
-  - osx
-
-jdk:
-  - oraclejdk8
-  - oraclejdk9
+matrix:
+  include:
+    - os: linux
+      jdk: oraclejdk8
+    - os: linux
+      jdk: oraclejdk9
+    - os: osx
+      osx_image: xcode9.3
 
 before_install:
   - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ before_install:
 script:
   - ./gradlew build
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-    - '$HOME/.gradle'
-    - '.gradle'
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
 sudo: false
 
+os:
+  - linux
+  - osx
+
 jdk:
   - oraclejdk8
   - oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: java
 
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+
 script:
- - ./gradlew build
+  - ./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ jdk:
 
 script:
   - ./gradlew build
+
+cache:
+  directories:
+    - '$HOME/.gradle'
+    - '.gradle'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ matrix:
       jdk: oraclejdk8
     - os: linux
       jdk: oraclejdk9
-    - os: linux
-      dist: xenial
-      jdk: oraclejdk8
     - os: osx
       osx_image: xcode9.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ jdk:
   - oraclejdk8
   - oraclejdk9
 
+before_install:
+  - chmod +x gradlew
+
 script:
   - ./gradlew build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,38 @@
 language: java
+#  Run each build in a container on a shared host via Docker.
 sudo: false
 
+# Environments for testing:
 matrix:
   include:
+    # Ubuntu 14.04 with Java 8
     - os: linux
       jdk: oraclejdk8
+    # Ubuntu 14.04 with Java 9
     - os: linux
       jdk: oraclejdk9
+    # Mac OSX 10.13
     - os: osx
       osx_image: xcode9.3
 
-before_install:
+# Before executing the build script:
+before_script:
+  # Initialize virtual display for Linux environments
   - if [[ "$TRAVIS_OS_NAME" == "linux"     ]]; then export DISPLAY=:99.0    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux"     ]]; then sh -e /etc/init.d/xvfb start    ; fi
+  # Make gradlew script executable
   - chmod +x gradlew
 
+# The build script.
 script:
   - ./gradlew build
 
+# Clean up before caching the Gradle data.
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+# Gradle caching settings (stores Gradle dependencies between builds).
 cache:
   directories:
     - $HOME/.gradle/caches/


### PR DESCRIPTION
#7 

This PR adds the Travis CI configuration for building the examples in Linux (both JDK 8 and JDK 9) and Mac environments.
The current configuration simply launches `./gradlew build` in these environments.

