### PR TITLE
Update JxBrowser version to 6.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
 }
 
 ext {
-    jxBrowserVersion = '6.20' // The version of JxBrowser used in the examples.
+    jxBrowserVersion = '6.21' // The version of JxBrowser used in the examples.
     guavaVersion = '25.0-jre' // Some of the examples use Guava.
 }
 
@@ -59,11 +59,15 @@ subprojects {
            2. uncomment the dependency for your platform.
         */
 
-        // Windows-only dependency
+        // Windows 32-bit
         //-------------------------
-        // compile "com.teamdev.jxbrowser:jxbrowser-win:${jxBrowserVersion}"
+        // compile "com.teamdev.jxbrowser:jxbrowser-win32:${jxBrowserVersion}"
 
-        // macOS-only dependency
+        // Windows 64-bit
+        //-------------------------
+        // compile "com.teamdev.jxbrowser:jxbrowser-win64:${jxBrowserVersion}"
+
+        // macOS 64-bit
         //-------------------------
         // compile "com.teamdev.jxbrowser:jxbrowser-mac:${jxBrowserVersion}"
 


### PR DESCRIPTION
This PR modifies `build.gradle` with the following changes:
- JxBrowser version has been upgraded to 6.21
- the list of the platform dependencies has been updated according to the latest [instruction](https://jxbrowser.support.teamdev.com/support/solutions/articles/9000012860-installation)